### PR TITLE
Csrf Violation Exception Error

### DIFF
--- a/src/CsrfSettings.php
+++ b/src/CsrfSettings.php
@@ -28,7 +28,7 @@ class CsrfSettings extends Settings
              * @var WebRequest $request
              */
             $request = Application::current()->request();
-            $this->domain = $request->host;
+            $this->domain = parse_url($request->host, PHP_URL_HOST);
         }
     }
 }


### PR DESCRIPTION
** Note: This issue was happening when being ran on localhost:8080 and having no absoluteWebsiteUrl specified

Adding fix for an issue where the default host being selected inside CsrfSettings from the request would include the port and not parse the url correctly this meant that when we attempted to verify the Referrer a CsrfViolation exception would be thrown.